### PR TITLE
Correctly construct additional flags

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -83,7 +83,7 @@ inputs:
     description: |-
       Space separated list of other Cloud Deploy flags, examples can be found:
       https://cloud.google.com/sdk/gcloud/reference/deploy/releases/create#FLAGS
-      Example: --from-k8s-manifest=manifest.yaml
+      Example: '--from-k8s-manifest=manifest.yaml --skaffold-version=skaffold_preview'
     required: false
 
   gcloud_version:

--- a/src/main.ts
+++ b/src/main.ts
@@ -153,7 +153,6 @@ export async function run(): Promise<void> {
     if (flags) {
       const flagList = parseFlags(flags);
       if (flagList) {
-        cmd.push('--flags');
         cmd = cmd.concat(flagList);
       }
     }

--- a/tests/unit/main.test.ts
+++ b/tests/unit/main.test.ts
@@ -267,12 +267,12 @@ describe('#run', function () {
   });
 
   it('sets flags if given', async function () {
-    this.stubs.getInput.withArgs('flags').returns('flag1=value1,flag2=value2');
+    this.stubs.getInput.withArgs('flags').returns('--flag1=value1 --flag2=value2');
     await run();
     const call = this.stubs.getExecOutput.getCall(0);
     expect(call).to.be;
     const args = call.args[1];
-    expect(args).to.include.members(['--flags', 'flag1=value1,flag2=value2']);
+    expect(args).to.include.members(['--flag1', 'value1', '--flag2', 'value2']);
   });
 
   it('uses default components without gcloud_component flag', async function () {


### PR DESCRIPTION
This PR addresses an issue with the `flags` input being incorrectly interpreted. Fixes #27.