### PR TITLE
Add support for deploy parameters feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,19 @@ jobs:
 
 -   `description`: (Optional) Include a description of the release.
 
+-   `deploy_parameters`: (Optional) Additional parameters to supply at release creation time.
+
+    ```yaml
+    with:
+      deploy_parameters: |-
+        parameter1=value1
+        parameter2=value2
+    ```
+
+    See the [Deploy Parameters](https://cloud.google.com/deploy/docs/parameters)
+    section in the Cloud Deploy documentation for details of how to use the corresponding
+    placeholders in your manifest(s).
+
 -   `flags`: (Optional) Space separated list of other Cloud Deploy flags,
     examples can be found [here][cd-flags]. This can be used to access features
     that are not exposed via this GitHub Action.

--- a/action.yml
+++ b/action.yml
@@ -79,6 +79,11 @@ inputs:
       Include a description of the release.
     required: false
 
+  deploy_parameters:
+    description: |-
+      Additional parameters to supply at release creation time.
+    required: false
+
   flags:
     description: |-
       Space separated list of other Cloud Deploy flags, examples can be found:

--- a/src/main.ts
+++ b/src/main.ts
@@ -87,6 +87,7 @@ export async function run(): Promise<void> {
     const annotations = parseKVString(getInput('annotations'));
     const labels = parseKVString(getInput('labels'));
     const description = getInput('description');
+    const deployParameters = parseKVString(getInput('deploy_parameters'));
     const flags = getInput('flags');
     const gcloudComponent = presence(getInput('gcloud_component'));
     const gcloudVersion = getInput('gcloud_version');
@@ -139,6 +140,9 @@ export async function run(): Promise<void> {
     }
     if (skaffoldFile) {
       cmd.push('--skaffold-file', skaffoldFile);
+    }
+    if (deployParameters) {
+      cmd.push('--deploy-parameters', joinKVString(deployParameters));
     }
 
     const allAnnotations = Object.assign({}, getDefaultAnnotations(), annotations);

--- a/tests/unit/main.test.ts
+++ b/tests/unit/main.test.ts
@@ -39,6 +39,7 @@ const fakeInputs: { [key: string]: string } = {
   sourceStagingDir: '',
   skaffoldFile: '',
   description: '',
+  deploy_parameters: '',
   flags: '',
   annotations: '',
   labels: '',
@@ -264,6 +265,20 @@ describe('#run', function () {
     expect(call).to.be;
     const args = call.args[1];
     expect(args).to.include.members(['--description', 'My description']);
+  });
+
+  it('sets deploy parameters if given', async function () {
+    this.stubs.getInput.withArgs('deploy_parameters').returns('param-key=param-value');
+
+    const expectedParameters = {
+      'param-key': 'param-value',
+    };
+
+    await run();
+    const call = this.stubs.getExecOutput.getCall(0);
+    expect(call).to.be;
+    const args = call.args[1];
+    expect(args).to.include.members(['--deploy-parameters', joinKVString(expectedParameters)]);
   });
 
   it('sets flags if given', async function () {


### PR DESCRIPTION
This PR adds support for the [deploy parameters](https://cloud.google.com/deploy/docs/parameters) feature, now GA in Cloud Deploy.