### PR TITLE
Add missing project_id input

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,8 @@ jobs:
     used. This is the equivalent of running 'gcloud alpha run' or 'gcloud beta
     run'. Valid values are `alpha` or `beta`.
 
+-   `project_id`: (Optional) ID of the Google Cloud project in which to deploy the service. The default value is computed from the environment.
+
 ## Outputs
 
 -   `name`: The full name of the release in Cloud Deploy, including project and

--- a/action.yml
+++ b/action.yml
@@ -84,6 +84,11 @@ inputs:
       Additional parameters to supply at release creation time.
     required: false
 
+  project_id:
+    description: |-
+      The Google Cloud Project ID. If unset, this is inherited from the environment.
+    required: false
+
   flags:
     description: |-
       Space separated list of other Cloud Deploy flags, examples can be found:

--- a/src/main.ts
+++ b/src/main.ts
@@ -92,6 +92,9 @@ export async function run(): Promise<void> {
     const gcloudComponent = presence(getInput('gcloud_component'));
     const gcloudVersion = getInput('gcloud_version');
 
+    // Common inputs
+    const projectId = getInput('project_id');
+
     // Throw errors if inputs aren't valid
     if (!name) {
       throw new Error('No release name set.');
@@ -161,8 +164,10 @@ export async function run(): Promise<void> {
       }
     }
 
+    // Set common flags
     // Set output format to json for easy parsing
     cmd.push('--format', 'json');
+    if (projectId) cmd.push('--project', projectId);
 
     // Install gcloud if not already installed.
     const gcloudVersionRequired = gcloudVersion ? gcloudVersion : await getLatestGcloudSDKVersion();

--- a/src/main.ts
+++ b/src/main.ts
@@ -77,10 +77,13 @@ export async function run(): Promise<void> {
     // Core inputs (required)
     const name = getInput('name');
     const deliveryPipeline = getInput('delivery_pipeline');
-    const region = getInput('region');
     const source = getInput('source');
     const buildArtifacts = getInput('build_artifacts');
     const images = parseKVString(getInput('images'));
+
+    // Common inputs
+    const projectId = getInput('project_id');
+    const region = getInput('region');
     const disableInitialRollout = getBooleanInput('disable_initial_rollout');
     const sourceStagingDir = getInput('gcs_source_staging_dir');
     const skaffoldFile = getInput('skaffold_file');
@@ -91,9 +94,6 @@ export async function run(): Promise<void> {
     const flags = getInput('flags');
     const gcloudComponent = presence(getInput('gcloud_component'));
     const gcloudVersion = getInput('gcloud_version');
-
-    // Common inputs
-    const projectId = getInput('project_id');
 
     // Throw errors if inputs aren't valid
     if (!name) {
@@ -117,6 +117,9 @@ export async function run(): Promise<void> {
     // Build base command from required inputs
     let cmd = ['deploy', 'releases', 'create', name, '--delivery-pipeline', deliveryPipeline];
 
+    if (projectId) {
+      cmd.push('--project', projectId);
+    }
     if (region) {
       cmd.push('--region', region);
     } else {
@@ -164,10 +167,8 @@ export async function run(): Promise<void> {
       }
     }
 
-    // Set common flags
     // Set output format to json for easy parsing
     cmd.push('--format', 'json');
-    if (projectId) cmd.push('--project', projectId);
 
     // Install gcloud if not already installed.
     const gcloudVersionRequired = gcloudVersion ? gcloudVersion : await getLatestGcloudSDKVersion();

--- a/tests/unit/main.test.ts
+++ b/tests/unit/main.test.ts
@@ -30,6 +30,7 @@ import { run } from '../../src/main';
 const fakeInputs = {
   delivery_pipeline: 'delivery-pipeline',
   name: 'release-001',
+  project_id: '',
   region: 'us-central1',
   source: 'src',
   build_artifacts: 'artifacts.json',
@@ -167,6 +168,19 @@ describe('#run', async () => {
       images: 'image1=image1:tag1',
     });
     assert.rejects(run, 'Both `build_artifacts` and `images` inputs set - please select only one.');
+  });
+
+  it('sets project if given', async (t) => {
+    const mocks = defaultMocks(t.mock, {
+      project_id: 'my-test-project',
+    });
+
+    await run();
+
+    expectSubArray(mocks.getExecOutput.mock.calls?.at(0)?.arguments?.at(1), [
+      '--project',
+      'my-test-project',
+    ]);
   });
 
   it('sets region if given', async (t) => {


### PR DESCRIPTION
This GitHub action is missing the common `project_id` input - I ran into this while trying to setup a deployment workflow on one of my repositories.

I added the missing input and then updated the README to reflect it.

<!--
Thank you for proposing a pull request! Please note that SOME TESTS WILL
LIKELY FAIL due to how GitHub exposes secrets in Pull Requests from forks.
Someone from the team will review your Pull Request and respond.

Please describe your change and any implementation details below.
-->
